### PR TITLE
fix(MiniTest): fix warning when starting Guard

### DIFF
--- a/test/teenager_test.rb
+++ b/test/teenager_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require_relative '../lib/teenager'
 
-class TeenagerTest < MiniTest::Unit::TestCase
+class TeenagerTest < MiniTest::Test
   def teenager
     Teenager.new
   end


### PR DESCRIPTION
Everything still works but starting Guard gives this warning about MiniTest class changes. It's safe to assume anyone running this during an interview will also be on Ruby 2.3.7 or higher.

The warning:

``` shell
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/wassim/Code/teenager/test/teenager_test.rb:5:in `<top (required)>'
```